### PR TITLE
Implement dismiss live activity when app is terminated

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ await _liveActivities.getInitUri()
 _activityId = await _liveActivities.createActivity(<String, String>{'text': 'Hello World'});
 ```
 
+* To dismiss the live activity when app terminated
+```dart
+_activityId = await _liveActivities.createActivity(
+      <String, String>{'text': 'Hello World'}
+      removeWhenAppIsKilled: true,
+    );
+```
+
 * Update a Live Activity
 ```dart
 if(_activityId != null) {

--- a/lib/flutter_live_activities.dart
+++ b/lib/flutter_live_activities.dart
@@ -32,10 +32,16 @@ class FlutterLiveActivities {
   /// When the activity is created, an activity id is returned.
   /// Data is a map of key/value pairs that will be transmitted to your iOS extension widget.
   /// Map is limited to String keys and values for now.
-  Future<String?> createActivity(Map<String, String> data) async {
+  Future<String?> createActivity(
+    Map<String, String> data, {
+    bool removeWhenAppIsKilled = false,
+  }) async {
     if (_isAndroid) return null;
 
-    return FlutterLiveActivitiesPlatform.instance.createActivity(data);
+    return FlutterLiveActivitiesPlatform.instance.createActivity(
+      data,
+      removeWhenAppIsKilled: removeWhenAppIsKilled,
+    );
   }
 
   /// Update an iOS 16.1+ live activity.

--- a/lib/flutter_live_activities_method_channel.dart
+++ b/lib/flutter_live_activities_method_channel.dart
@@ -41,9 +41,15 @@ class MethodChannelFlutterLiveActivities extends FlutterLiveActivitiesPlatform {
   }
 
   @override
-  Future<String?> createActivity(Map<String, String> data) async {
-    return _methodChannel.invokeMethod<String>(
-        'createActivity', <String, dynamic>{'data': data});
+  Future<String?> createActivity(
+    Map<String, String> data, {
+    bool removeWhenAppIsKilled = false,
+  }) async {
+    return _methodChannel
+        .invokeMethod<String>('createActivity', <String, dynamic>{
+      'data': data,
+      'removeWhenAppIsKilled': removeWhenAppIsKilled,
+    });
   }
 
   @override

--- a/lib/flutter_live_activities_platform_interface.dart
+++ b/lib/flutter_live_activities_platform_interface.dart
@@ -37,7 +37,10 @@ abstract class FlutterLiveActivitiesPlatform extends PlatformInterface {
     throw UnimplementedError('getAllActivities() has not been implemented.');
   }
 
-  Future<String?> createActivity(Map<String, String> data) {
+  Future<String?> createActivity(
+    Map<String, String> data, {
+    bool removeWhenAppIsKilled = false,
+  }) {
     throw UnimplementedError('createActivity() has not been implemented.');
   }
 


### PR DESCRIPTION
In this version of the plugin, when the app was put in terminate state, the live activity was not dismissed. After this pr, users will be able to dismiss the live activity widget when the app goes into terminated state, using the removeWhenAppIsKilled parameter.