### PR TITLE
fix some build error

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '11.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -215,6 +215,7 @@
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
 				8E66A351ECE4730D6CB5F797 /* [CP] Check Pods Manifest.lock */,
+				2770E02F291511C600771F44 /* Embed Foundation Extensions */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
@@ -222,7 +223,6 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				1613AA33CF4A811D03437973 /* [CP] Embed Pods Frameworks */,
-				2770E02F291511C600771F44 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  extended_image: ^6.3.2
+  extended_image: ^8.2.1
   path: ^1.8.2
   path_provider: ^2.0.11
 


### PR DESCRIPTION

<img width="949" alt="image" src="https://github.com/user-attachments/assets/587671f3-c6ef-4a5a-9e3c-09cdd2a8d88e">

- The method 'ExtendedPagePosition.copyWith' doesn't have the named parameter 'devicePixelRatio' of overridden method 'ViewportOffset with ScrollMetrics.copyWith' 

<img width="954" alt="image" src="https://github.com/user-attachments/assets/4fe65bb6-c8c6-4318-8264-e93088c9d9b9">

-  Specs satisfying the `path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)` dependency were found, but they required a higher minimum deployment target 

<img width="639" alt="image" src="https://github.com/user-attachments/assets/b4ffb298-4173-4cbb-950e-a92d6f899a7e">

- Error (Xcode): Cycle inside Runner; building could produce unreliable results [flutter issues](https://github.com/flutter/flutter/issues/135739#issuecomment-1742333093)